### PR TITLE
feat(sr-preset)!: change angular preset to conventionalcommits on releaserc

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,7 +2,10 @@
   "branches": ["main"],
   "tagFormat": "${version}",
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer", {
+        "preset": "conventionalcommits"
+    }],
     [
       "@google/semantic-release-replace-plugin",
       {
@@ -52,7 +55,10 @@
         ]
       }
     ],
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator", {
+        "preset": "conventionalcommits"
+      }],
     [
       "@semantic-release/changelog",
       {


### PR DESCRIPTION
Changing `angular` preset to `conventionalcommits`


BREAKING CHANGE: Now conventionalcommits syntax is required to trigger the release