### PR TITLE
fix(flake8): flake8 is now on github

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,8 @@ repos:
         - id: black
           exclude: ^docs/
 
-    - repo: https://gitlab.com/pycqa/flake8
-      rev: 3.7.9
+    - repo: https://github.com/pycqa/flake8
+      rev: 6.0.0
       hooks:
         - id: flake8
           types:


### PR DESCRIPTION
Adding the correct path to the flake8 repo and its latest version.